### PR TITLE
numeric logging levels

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -17,8 +17,26 @@ func (f *SimpleFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// This is a hack. I don't like it but it does the job.
 	dataStr := string(dataByte)
 	dataStr = strings.Replace(dataStr, "\"msg\":", "\"message\":", 1)
+
+	// logz.io wants numeric levels not strings, otherwise you get a parse error
+	// ie want "level":4 not "level":"info"
+	//
+	// could adapt the Format() function from logrus/json_formatter.go,
+	// but this certainly "Formats" the output
+	//
+	// Logrus has six logging levels: Debug, Info, Warning, Error, Fatal and Panic
+	// numeric levels are from logrus/logrus.go, var AllLevels
+	//
+	dataStr = strings.Replace(dataStr, "\"level\":\"panic\"", "\"level\":0", 1)
+	dataStr = strings.Replace(dataStr, "\"level\":\"fatal\"", "\"level\":1", 1)
+	dataStr = strings.Replace(dataStr, "\"level\":\"error\"", "\"level\":2", 1)
+	dataStr = strings.Replace(dataStr, "\"level\":\"warning\"", "\"level\":3", 1)
+	dataStr = strings.Replace(dataStr, "\"level\":\"info\"", "\"level\":4", 1)
+	dataStr = strings.Replace(dataStr, "\"level\":\"debug\"", "\"level\":5", 1)
+
 	return []byte(dataStr), nil
 }

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -23,7 +23,7 @@ func TestSimpleFormatterFormat(t *testing.T) {
 	if err != nil {
 		t.Errorf("%s expected not to fail: %s", name, err)
 	}
-	if expected := "{\"level\":\"panic\",\"message\":\"\",\"time\":\"0001-01-01T00:00:00Z\",\"user\":\"bla\"}\n"; string(data) != expected {
+	if expected := "{\"level\":0,\"message\":\"\",\"time\":\"0001-01-01T00:00:00Z\",\"user\":\"bla\"}\n"; string(data) != expected {
 		t.Errorf("%s expected data to be %s but got %s", name, expected, string(data))
 	}
 }


### PR DESCRIPTION
logz.io wants numeric levels not strings, otherwise you get a parse error